### PR TITLE
🔧修复安全问题 `BAN-B701`(deepsource)

### DIFF
--- a/src/plugins/ddcheck/data_source.py
+++ b/src/plugins/ddcheck/data_source.py
@@ -25,7 +25,7 @@ vtb_list_path = data_path / "vtb_list.json"
 dir_path = Path(__file__).parent
 template_path = dir_path / "template"
 env = jinja2.Environment(
-    loader=jinja2.FileSystemLoader(template_path), enable_async=True
+    loader=jinja2.FileSystemLoader(template_path), enable_async=True, autoescape=True
 )
 
 


### PR DESCRIPTION
Using Jinja2 templates without autoescaping enabled leaves application vulnerable to [XSS attacks](https://owasp.org/www-project-top-ten/2017/A72017-Cross-SiteScripting_(XSS).

Autoescaping is the concept of automatically escaping special characters. Special characters for HTML, XML and XHTMl are &, >, <, " as well as '. These characters carry specific meanings so need to be replaced by so called entities if you want to use them for text. Not doing so makes application susceptible to Cross Site Scripting (XSS) attacks.

When configuring the Jinja2 environment, the option to use autoescaping on input can be specified. By default, autoescaping is disabled. When enabled, Jinja2 will filter input strings to escape any HTML content submitted via template variables.